### PR TITLE
Read latest request body instead of snapshot copy

### DIFF
--- a/signer.go
+++ b/signer.go
@@ -41,6 +41,9 @@ func (signer *Signer) Sign(req *http.Request) error {
 // The getRequestBody extracts the body content from the given
 // http request and returns in []byte format.
 func getRequestBody(req *http.Request) ([]byte, error) {
+	if req.Body == nil {
+		return nil, nil
+	}
 	bodyBytes, err := io.ReadAll(req.Body)
 	if err != nil {
 		return nil, err

--- a/signer.go
+++ b/signer.go
@@ -3,7 +3,7 @@ package oauth
 import (
 	"crypto/rsa"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -41,14 +41,11 @@ func (signer *Signer) Sign(req *http.Request) error {
 // The getRequestBody extracts the body content from the given
 // http request and returns in []byte format.
 func getRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
+	bodyBytes, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
 	}
-	getBody, e := req.GetBody()
-	if e != nil {
-		return nil, e
-	}
-	defer func() { _ = getBody.Close() }()
+	defer req.Body.Close()
 
-	return ioutil.ReadAll(getBody)
+	return bodyBytes, nil
 }


### PR DESCRIPTION
Addressing issue https://github.com/Mastercard/oauth1-signer-go/issues/7

When reading the request body to be signed, the actual body could have been modified since when it was first created (for example when using an encryption middleware). 
Instead of using `req.GetBody()` (which returns a snapshot copy, see https://github.com/golang/go/blob/master/src/net/http/request.go#L919), we should read the actual latest content of the body.

In addition, I have swapped the deprecated `ioutil` package for `io`


### PR checklist

- [x] An issue/feature request has been created for this PR
- [X] Pull Request title clearly describes the work in the pull request and the Pull Request description provides details about how to validate the work. Missing information here may result in a delayed response.
- [X] File the PR against the `master` branch
- [X] The code in this PR is covered by unit tests
