### PR TITLE
Add leading slash to URL Path in getBaseUrlString function, if one does not already exist

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -188,8 +188,8 @@ func getBaseUrlString(u *url.URL) string {
 		host = hostPort[0]
 	}
 	path := u.EscapedPath()
-	if path == "" {
-		path = "/"
+	if path == "" || path[0] != '/' {
+		path = "/" + path
 	}
 	return fmt.Sprintf("%v://%v%v", scheme, host, path)
 }

--- a/oauth_test.go
+++ b/oauth_test.go
@@ -253,6 +253,15 @@ func TestGetBaseUrlString_ShouldAddTrailingSlash(t *testing.T) {
 	}
 }
 
+func TestGetBaseUrlString_ShouldAddLeadingSlashToPath(t *testing.T) {
+	u, _ := url.Parse("https://api.mastercard.com")
+	u.Path = "test/service"
+	baseUrl := getBaseUrlString(u)
+	if "https://api.mastercard.com/test/service" != baseUrl {
+		t.Errorf("Something went wrong, got %v", baseUrl)
+	}
+}
+
 func TestGetBaseUrlString_ShouldUseLowercaseSchemesAndHosts(t *testing.T) {
 	u, _ := url.Parse("HTTPS://API.MASTERCARD.COM/TEST")
 	baseUrl := getBaseUrlString(u)


### PR DESCRIPTION
<!-- Please check the completed items below -->
### PR checklist

- [x] An issue/feature request has been created for this PR
- [x] Pull Request title clearly describes the work in the pull request and the Pull Request description provides details about how to validate the work. Missing information here may result in a delayed response.
- [x] File the PR against the `master` branch
- [x] The code in this PR is covered by unit tests

#### Link to issue/feature request: #13

#### Description
When the URL path doesn't have a leading slash, for example, when using the `JoinPath` function, `getBaseUrlString` does not correctly concatenate the host and path components. This is handled correctly in the stdlib net/url package, for example, when calling `url.String()`.

This MR adds a similar check to the one used in net/url, to correctly handle this scenario.
